### PR TITLE
Add ansible version 9 and exclude Python 3.9 constraint

### DIFF
--- a/.github/workflows/ansible-role-ci.yml
+++ b/.github/workflows/ansible-role-ci.yml
@@ -19,6 +19,10 @@ jobs:
         ansible-version:
           - 'ansible>=7.0.0,<8.0.0'
           - 'ansible>=8.0.0,<9.0.0'
+          - 'ansible>=0.0.0,<10.0.0'
+        exclude:
+          - python-version: '3.9'
+            ansible-version: 'ansible>=9.0.0,<10.0.0'
 
     steps:
       - name: Check out the codebase


### PR DESCRIPTION
This pull request adds ansible version 9 to the project and includes a constraint to exclude Python 3.9.