### PR TITLE
Update Ansible version requirements

### DIFF
--- a/.github/workflows/ansible-role-ci.yml
+++ b/.github/workflows/ansible-role-ci.yml
@@ -17,10 +17,11 @@ jobs:
           - '3.11'
           - '3.12'
         ansible-version:
-          - 'ansible>=7.0.0,<8.0.0'
           - 'ansible>=8.0.0,<9.0.0'
-          - 'ansible>=0.0.0,<10.0.0'
+          - 'ansible>=9.0.0,<10.0.0'
         exclude:
+          - python-version: '3.12'
+            ansible-version: 'ansible>=8.0.0,<9.0.0'
           - python-version: '3.9'
             ansible-version: 'ansible>=9.0.0,<10.0.0'
 


### PR DESCRIPTION
This pull request updates the Ansible version requirements to 'ansible>=9.0.0,<10.0.0'. And drop support for Ansible 7 to close #113