### PR TITLE
Remove Python 3.9 and Ansible 9.0.0 support

### DIFF
--- a/.github/workflows/ansible-role-ci.yml
+++ b/.github/workflows/ansible-role-ci.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'
@@ -22,8 +21,6 @@ jobs:
         exclude:
           - python-version: '3.12'
             ansible-version: 'ansible>=8.0.0,<9.0.0'
-          - python-version: '3.9'
-            ansible-version: 'ansible>=9.0.0,<10.0.0'
 
     steps:
       - name: Check out the codebase


### PR DESCRIPTION
This pull request removes support for Python 3.9 and Ansible 9.0.0.