### PR TITLE
Update ansible-role-ci.yml to include Ansible 11

### DIFF
--- a/.github/workflows/ansible-role-ci.yml
+++ b/.github/workflows/ansible-role-ci.yml
@@ -17,6 +17,7 @@ jobs:
           - '3.12'
         ansible-version:
           - 'ansible>=10.0.0,<11.0.0'
+          - 'ansible>=11.0.0,<12.0.0'
 
     steps:
       - name: Check out the codebase


### PR DESCRIPTION
Ansible [11](https://pypi.org/project/ansible/11.0.0/) was released in November.