### PR TITLE
Add MOLECULE_VERSION environment variable for dependency management

### DIFF
--- a/.github/workflows/ansible-role-ci.yml
+++ b/.github/workflows/ansible-role-ci.yml
@@ -4,6 +4,9 @@ name: Ansible Role CI
 on:
   workflow_call:
 
+env:
+  MOLECULE_VERSION: 'molecule==24.12.0'
+
 jobs:
 
   molecule:
@@ -52,7 +55,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "${{ matrix.ansible-version }}" ansible-lint molecule molecule-plugins[docker] docker flake8 flake8-bugbear flake8-docstrings flake8-import-order flake8-pylint flake8-github-annotations pytest pytest-testinfra pymarkdownlnt yamllint
+          python -m pip install "${{ matrix.ansible-version }}" ansible-lint ${{ env.MOLECULE_VERSION }} molecule-plugins[docker] docker flake8 flake8-bugbear flake8-docstrings flake8-import-order flake8-pylint flake8-github-annotations pytest pytest-testinfra pymarkdownlnt yamllint
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Lint with yamllint


### PR DESCRIPTION
Introduce an environment variable for MOLECULE_VERSION to streamline dependency installation in the CI workflow. This change ensures the specified version of Molecule is consistently used.