### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint Code Base


### PR DESCRIPTION
Potential fix for [https://github.com/hspaans/.github/security/code-scanning/1](https://github.com/hspaans/.github/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, the minimal least-privilege baseline is:

- `contents: read`

This does not change functional behavior for typical lint/check workflows that only need to read repository contents, and it documents/security-locks intended token scope. Place it after the `on:` block and before `jobs:` (or directly after `name:` is also valid).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
